### PR TITLE
Remove wrong Wikidata item for A+ Glass

### DIFF
--- a/data/brands/shop/car_repair.json
+++ b/data/brands/shop/car_repair.json
@@ -93,7 +93,6 @@
       "locationSet": {"include": ["fr"]},
       "tags": {
         "brand": "A+ Glass",
-        "brand:wikidata": "Q123409768",
         "name": "A+ Glass",
         "service:vehicle:glass": "yes",
         "shop": "car_repair"


### PR DESCRIPTION
Wikidata item Q123409768 is for a different shop named "Active Green + Ross", located in Canada. The item is already linked to the correct brand in NSI, with ID [activegreenross-9c9847](https://github.com/osmlab/name-suggestion-index/blob/a9d2f2292f5d510b8e5bd411c7e3b57e1419232b/data/brands/shop/car_repair.json#L119).

I could not find a matching Wikidata item for A+ Glass.